### PR TITLE
chore: bump version to v0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tabular2mcap"
-version = "0.1.11"
+version = "0.1.12"
 description = "Convert tabular data (CSV, Parquet, Excel, etc.) to MCAP format with support for ROS2 and JSON schemas"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -2054,7 +2054,7 @@ wheels = [
 
 [[package]]
 name = "tabular2mcap"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## Summary

- Bump version to v0.1.12

## Test plan

- [x] Version updated in pyproject.toml
- [x] uv.lock updated